### PR TITLE
Fix @n8n/community-nodes verification violations (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2026-06-02
+
+### Fixed
+- Pass authentication through `httpRequestWithAuthentication` instead of injecting the `X-API-KEY` header manually (required by the `@n8n/eslint-plugin-community-nodes` verification ruleset).
+- Remove the `overrides` field from `package.json` (not permitted in community node packages).
+
 ## [1.2.0] - 2026-06-02
 
 ### Fixed

--- a/dist/nodes/EmailConnect/GenericFunctions.js
+++ b/dist/nodes/EmailConnect/GenericFunctions.js
@@ -7,12 +7,10 @@ exports.getAliasOptions = getAliasOptions;
 const n8n_workflow_1 = require("n8n-workflow");
 exports.API_BASE_URL = 'https://app.emailconnect.eu';
 async function emailConnectApiRequest(method, resource, body = {}, qs = {}, uri, headers = {}) {
-    const credentials = await this.getCredentials('emailConnectApi');
     const hasBody = Object.keys(body).length > 0;
     const options = {
         method,
         headers: {
-            'X-API-KEY': credentials.apiKey,
             ...(hasBody && { 'Content-Type': 'application/json' }),
             ...headers,
         },
@@ -22,7 +20,9 @@ async function emailConnectApiRequest(method, resource, body = {}, qs = {}, uri,
         json: true,
     };
     try {
-        return await this.helpers.httpRequest(options);
+        // Authentication (the X-API-KEY header) is applied from the credential's
+        // `authenticate` block by httpRequestWithAuthentication.
+        return await this.helpers.httpRequestWithAuthentication.call(this, 'emailConnectApi', options);
     }
     catch (error) {
         throw new n8n_workflow_1.NodeApiError(this.getNode(), error);

--- a/nodes/EmailConnect/GenericFunctions.ts
+++ b/nodes/EmailConnect/GenericFunctions.ts
@@ -20,14 +20,11 @@ export async function emailConnectApiRequest(
 	uri?: string,
 	headers: any = {},
 ): Promise<any> {
-	const credentials = await this.getCredentials('emailConnectApi');
-
 	const hasBody = Object.keys(body).length > 0;
 
 	const options: IHttpRequestOptions = {
 		method,
 		headers: {
-			'X-API-KEY': credentials.apiKey,
 			...(hasBody && { 'Content-Type': 'application/json' }),
 			...headers,
 		},
@@ -38,7 +35,9 @@ export async function emailConnectApiRequest(
 	};
 
 	try {
-		return await this.helpers.httpRequest(options);
+		// Authentication (the X-API-KEY header) is applied from the credential's
+		// `authenticate` block by httpRequestWithAuthentication.
+		return await this.helpers.httpRequestWithAuthentication.call(this, 'emailConnectApi', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as any);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-emailconnect",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -6098,6 +6098,21 @@
         "transliteration": "2.3.5",
         "xml2js": "0.6.2",
         "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/napi-postinstall": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "n8n community node for EmailConnect - Email automation and webhook integration",
   "keywords": [
     "n8n-community-node-package",
@@ -69,8 +69,5 @@
   },
   "peerDependencies": {
     "n8n-workflow": "*"
-  },
-  "overrides": {
-    "form-data": "^4.0.4"
   }
 }

--- a/test/domain-dropdown-fix.test.js
+++ b/test/domain-dropdown-fix.test.js
@@ -8,10 +8,10 @@ const { getDomainOptions } = require('../dist/nodes/EmailConnect/GenericFunction
 
 function makeContext(httpImpl) {
 	return {
-		getCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-api-key' }),
 		getNode: jest.fn().mockReturnValue({ name: 'EmailConnect Trigger', type: 'emailConnectTrigger' }),
 		helpers: {
-			httpRequest: jest.fn().mockImplementation(httpImpl),
+			// The node authenticates via httpRequestWithAuthentication.
+			httpRequestWithAuthentication: jest.fn().mockImplementation(httpImpl),
 		},
 	};
 }


### PR DESCRIPTION
1.2.0 published with provenance and **passed the scanner's provenance check**, but `@n8n/scan-community-package` then flagged two ESLint violations from `@n8n/eslint-plugin-community-nodes` (stricter than the `eslint-plugin-n8n-nodes-base` rules used in local CI):

1. **`no-http-request-with-manual-auth`** — `GenericFunctions.ts` now calls `httpRequestWithAuthentication('emailConnectApi', ...)`; the manual `getCredentials()` + `X-API-KEY` header is gone (the credential's `authenticate` block supplies it).
2. **`no-overrides-field`** — removed the `package.json` `overrides` entry (not allowed in community packages).

Verified by running the scanner's **exact ruleset against the packed tarball → 0 errors**. Dropdown test updated to mock the new helper; 36 tests pass.

After merge, a v1.2.1 release will publish with provenance and the scanner should pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)