### PR TITLE
fix(trigger): send X-EmailConnect-Source header on webhook/alias upsert (v1.3.1)

### DIFF
--- a/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
+++ b/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
@@ -3,6 +3,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailConnectTrigger = void 0;
 const n8n_workflow_1 = require("n8n-workflow");
 const GenericFunctions_1 = require("../EmailConnect/GenericFunctions");
+// Sanctioned trusted-source header: the backend auto-verifies webhooks
+// created/updated by known integrations (n8n-node, zapier, make). Sent on
+// every atomic upsert as belt-and-braces alongside the autoVerify body flag.
+const TRUSTED_SOURCE_HEADERS = { 'X-EmailConnect-Source': 'n8n-node' };
 // ---------------------------------------------------------------------------
 // Helper: build the body for the atomic POST /api/webhooks/alias upsert.
 // Shared by create() and the URL-change path so both use the one mechanism
@@ -50,7 +54,7 @@ async function updateWebhookUrlAndVerify(context, webhookUrl) {
         || `n8n trigger (${context.getNode().name})`;
     const webhookDescription = `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
     const body = buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescription);
-    const result = await GenericFunctions_1.emailConnectApiRequest.call(context, 'POST', '/api/webhooks/alias', body);
+    const result = await GenericFunctions_1.emailConnectApiRequest.call(context, 'POST', '/api/webhooks/alias', body, {}, undefined, TRUSTED_SOURCE_HEADERS);
     if ((_a = result === null || result === void 0 ? void 0 : result.webhook) === null || _a === void 0 ? void 0 : _a.id)
         staticData.webhookId = result.webhook.id;
     if ((_b = result === null || result === void 0 ? void 0 : result.alias) === null || _b === void 0 ? void 0 : _b.id)
@@ -310,7 +314,7 @@ class EmailConnectTrigger {
                         }
                         // Atomic upsert: creates/updates webhook + alias and auto-verifies.
                         const webhookAliasData = buildWebhookAliasBody(this, webhookUrl, webhookName, webhookDescription);
-                        const result = await GenericFunctions_1.emailConnectApiRequest.call(this, 'POST', '/api/webhooks/alias', webhookAliasData);
+                        const result = await GenericFunctions_1.emailConnectApiRequest.call(this, 'POST', '/api/webhooks/alias', webhookAliasData, {}, undefined, TRUSTED_SOURCE_HEADERS);
                         if (!result.success) {
                             throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Failed to create/update webhook and alias: ${result.message || 'Unknown error'}`);
                         }

--- a/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
+++ b/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
@@ -11,6 +11,11 @@ import {
 
 import { emailConnectApiRequest, getDomainOptions } from '../EmailConnect/GenericFunctions';
 
+// Sanctioned trusted-source header: the backend auto-verifies webhooks
+// created/updated by known integrations (n8n-node, zapier, make). Sent on
+// every atomic upsert as belt-and-braces alongside the autoVerify body flag.
+const TRUSTED_SOURCE_HEADERS = { 'X-EmailConnect-Source': 'n8n-node' };
+
 // ---------------------------------------------------------------------------
 // Helper: build the body for the atomic POST /api/webhooks/alias upsert.
 // Shared by create() and the URL-change path so both use the one mechanism
@@ -69,7 +74,15 @@ async function updateWebhookUrlAndVerify(
 	const webhookDescription = `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
 
 	const body = buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescription);
-	const result = await emailConnectApiRequest.call(context, 'POST', '/api/webhooks/alias', body);
+	const result = await emailConnectApiRequest.call(
+		context,
+		'POST',
+		'/api/webhooks/alias',
+		body,
+		{},
+		undefined,
+		TRUSTED_SOURCE_HEADERS,
+	);
 
 	if (result?.webhook?.id) staticData.webhookId = result.webhook.id;
 	if (result?.alias?.id) staticData.aliasId = result.alias.id;
@@ -352,7 +365,15 @@ export class EmailConnectTrigger implements INodeType {
 
 					// Atomic upsert: creates/updates webhook + alias and auto-verifies.
 					const webhookAliasData = buildWebhookAliasBody(this, webhookUrl, webhookName, webhookDescription);
-					const result = await emailConnectApiRequest.call(this, 'POST', '/api/webhooks/alias', webhookAliasData);
+					const result = await emailConnectApiRequest.call(
+						this,
+						'POST',
+						'/api/webhooks/alias',
+						webhookAliasData,
+						{},
+						undefined,
+						TRUSTED_SOURCE_HEADERS,
+					);
 
 					if (!result.success) {
 						throw new NodeOperationError(this.getNode(), `Failed to create/update webhook and alias: ${result.message || 'Unknown error'}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-emailconnect",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "n8n community node for EmailConnect - Email automation and webhook integration",
   "keywords": [
     "n8n-community-node-package",

--- a/test/trusted-source-header.test.js
+++ b/test/trusted-source-header.test.js
@@ -1,0 +1,117 @@
+/**
+ * The X-EmailConnect-Source trusted-source header must be sent on every
+ * POST /api/webhooks/alias upsert. The backend auto-verifies webhooks
+ * created/updated by known integrations (n8n-node, zapier, make) based on
+ * this header — belt-and-braces alongside the autoVerify body flag.
+ */
+
+const { EmailConnectTrigger } = require('../dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js');
+
+jest.mock('../dist/nodes/EmailConnect/GenericFunctions.js', () => ({
+  emailConnectApiRequest: jest.fn(),
+  getDomainOptions: jest.fn().mockResolvedValue([]),
+}));
+
+const { emailConnectApiRequest } = require('../dist/nodes/EmailConnect/GenericFunctions.js');
+
+const TRUSTED_HEADERS = { 'X-EmailConnect-Source': 'n8n-node' };
+
+describe('Trusted-source header on webhook/alias upsert', () => {
+  let triggerNode;
+  let mockContext;
+  let mockStaticData;
+
+  beforeEach(() => {
+    triggerNode = new EmailConnectTrigger();
+    emailConnectApiRequest.mockReset();
+
+    mockStaticData = {
+      aliasMode: 'specific',
+      domainId: 'test-domain-id',
+      aliasLocalPart: 'support',
+    };
+
+    mockContext = {
+      getNodeWebhookUrl: jest.fn(),
+      getWorkflowStaticData: jest.fn().mockReturnValue(mockStaticData),
+      getNode: jest.fn().mockReturnValue({ name: 'Test EmailConnect Trigger' }),
+      getNodeParameter: jest.fn((param) => {
+        const params = {
+          aliasMode: 'specific',
+          domainId: 'test-domain-id',
+          aliasLocalPart: 'support',
+          webhookName: 'My webhook',
+          webhookDescription: 'My description',
+        };
+        return params[param] || '';
+      }),
+      getCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-api-key' }),
+    };
+  });
+
+  test('create() sends the trusted-source header on the atomic upsert', async () => {
+    const webhookUrl =
+      'https://n8n.example.com/webhook/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+    mockContext.getNodeWebhookUrl.mockReturnValue(webhookUrl);
+
+    emailConnectApiRequest
+      // GET /api/domains/{id}
+      .mockResolvedValueOnce({ id: 'test-domain-id', domain: 'example.com', webhookId: '' })
+      // POST /api/webhooks/alias
+      .mockResolvedValueOnce({
+        success: true,
+        webhook: { id: 'webhook-1' },
+        alias: { id: 'alias-1' },
+      });
+
+    const result = await triggerNode.webhookMethods.default.create.call(mockContext);
+
+    expect(result).toBe(true);
+    expect(emailConnectApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/webhooks/alias',
+      expect.objectContaining({
+        domainId: 'test-domain-id',
+        webhookUrl,
+        autoVerify: true,
+      }),
+      {},
+      undefined,
+      expect.objectContaining(TRUSTED_HEADERS),
+    );
+  });
+
+  test('checkExists() URL-switch re-upsert sends the trusted-source header', async () => {
+    const storedUrl =
+      'https://n8n.example.com/webhook/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+    const currentUrl =
+      'https://n8n.example.com/webhook-test/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+    mockContext.getNodeWebhookUrl.mockReturnValue(currentUrl);
+    mockStaticData.webhookId = 'existing-webhook-id';
+    mockStaticData.aliasId = 'test-alias-id';
+
+    emailConnectApiRequest
+      // GET /api/webhooks/{id} — URL differs from current
+      .mockResolvedValueOnce({ id: 'existing-webhook-id', url: storedUrl, verified: true })
+      // POST /api/webhooks/alias (re-upsert)
+      .mockResolvedValueOnce({
+        success: true,
+        webhook: { id: 'existing-webhook-id' },
+        alias: { id: 'test-alias-id' },
+      });
+
+    const result = await triggerNode.webhookMethods.default.checkExists.call(mockContext);
+
+    expect(result).toBe(true);
+    expect(emailConnectApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/webhooks/alias',
+      expect.objectContaining({ webhookUrl: currentUrl, autoVerify: true }),
+      {},
+      undefined,
+      expect.objectContaining(TRUSTED_HEADERS),
+    );
+  });
+});

--- a/test/webhook-url-switching.test.js
+++ b/test/webhook-url-switching.test.js
@@ -78,6 +78,9 @@ describe('EmailConnect Webhook URL Switching', () => {
           autoVerify: true,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Test)',
         }),
+        {},
+        undefined,
+        { 'X-EmailConnect-Source': 'n8n-node' },
       );
       // No PUT or /verify calls anymore
       const methods = emailConnectApiRequest.mock.calls.map(c => `${c[0]} ${c[1]}`);
@@ -107,6 +110,9 @@ describe('EmailConnect Webhook URL Switching', () => {
           autoVerify: true,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Production)',
         }),
+        {},
+        undefined,
+        { 'X-EmailConnect-Source': 'n8n-node' },
       );
     });
 
@@ -210,6 +216,9 @@ describe('EmailConnect Webhook URL Switching', () => {
       // Should re-upsert via the atomic endpoint with the current (production) URL
       expect(emailConnectApiRequest).toHaveBeenNthCalledWith(2, 'POST', '/api/webhooks/alias',
         expect.objectContaining({ webhookUrl: currentUrl, autoVerify: true }),
+        {},
+        undefined,
+        { 'X-EmailConnect-Source': 'n8n-node' },
       );
     });
 
@@ -285,6 +294,9 @@ describe('EmailConnect Webhook URL Switching', () => {
           webhookUrl: testUrl,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Test)',
         }),
+        {},
+        undefined,
+        { 'X-EmailConnect-Source': 'n8n-node' },
       );
     });
 
@@ -311,6 +323,9 @@ describe('EmailConnect Webhook URL Switching', () => {
           webhookUrl: productionUrl,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Production)',
         }),
+        {},
+        undefined,
+        { 'X-EmailConnect-Source': 'n8n-node' },
       );
     });
 


### PR DESCRIPTION
## Why

The v1.3.0 trigger node's first Execute step failed with a 500 from `POST /api/webhooks/alias`, leaving an orphan unverified webhook and no alias. Root cause was in the backend (`autoVerify` wrote a nonexistent `verificationToken` column) and is fixed in emailconnect-app (`fix/webhook-alias-autoverify`), which also makes the alias endpoint honor the `X-EmailConnect-Source` trusted-source header — same as `POST /api/webhooks` and `PUT /api/webhooks/:id` already did.

## What

- Send `X-EmailConnect-Source: n8n-node` on both atomic upsert call sites (`create()` and the URL-switch re-upsert in `checkExists()`), so trigger webhooks are born verified at creation instead of relying solely on the `autoVerify` body flag.
- New regression test `test/trusted-source-header.test.js` covering both call sites (written first, watched fail).
- Updated the five pinned call-shape assertions in `test/webhook-url-switching.test.js` for the new header args.
- Version bump 1.3.0 → 1.3.1.

## Verification

- 38/38 jest tests pass, eslint clean.
- Note: requires the backend fix to be deployed for end-to-end effect; harmless against the current production backend (header is ignored there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)