### PR TITLE
fix(trigger): teardown safety — atomic endpoint, supersede guard, name preservation (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2026-06-11
+
+### Fixed
+- **Test-session teardown no longer breaks a just-published workflow.** n8n deletes the test webhook registration even after publishing, and test + production share one EmailConnect webhook/alias (`firstOrCreate` by email). The trigger's `delete()` now probes ownership first: if the stored webhook's URL no longer matches this registration, it was superseded and teardown is skipped, preserving the live production registration.
+- **Webhook name/description survive the test→production URL switch.** Activation runs without the test session's static data, so the re-upsert used to rename user-named webhooks to the generated `n8n trigger (...)` fallback. Precedence is now node parameter → static data → the webhook's current values → generated.
+- **Webhook "Update" keeps the webhook verified.** The regular node's webhook update (`PUT /api/webhooks/:id`) now sends the `X-EmailConnect-Source` trusted-source header; without it the backend resets `verified` on any non-test URL change.
+
+### Changed
+- Teardown prefers a single atomic `POST /api/webhooks/alias/teardown` call (re-points/cascades aliases and deletes the webhook in one transaction, with `expectedUrl` as a CAS guard), falling back to the legacy multi-call sequence on older backends.
+- Dropped the deprecated `autoVerify` body flag from the webhook/alias upsert — the backend ignores it; the `X-EmailConnect-Source` header is the sole auto-verification mechanism.
+
+## [1.3.1] - 2026-06-10
+
+### Fixed
+- **Send `X-EmailConnect-Source: n8n-node` on the webhook/alias upsert.** The backend auto-verifies webhooks created/updated by trusted integrations based on this header; relying solely on the `autoVerify` body flag broke against deployed backends (500 on first Execute step, leaving an orphan unverified webhook and no alias).
+
 ## [1.3.0] - 2026-06-02
 
 ### Fixed

--- a/dist/nodes/EmailConnect/EmailConnect.node.js
+++ b/dist/nodes/EmailConnect/EmailConnect.node.js
@@ -624,7 +624,11 @@ class EmailConnect {
                         const body = { name, url };
                         if (description)
                             body.description = description;
-                        const responseData = await GenericFunctions_1.emailConnectApiRequest.call(this, 'PUT', `/api/webhooks/${webhookId}`, body);
+                        // Trusted-source header keeps the webhook verified on URL change —
+                        // without it the backend resets `verified` for any non-test URL.
+                        const responseData = await GenericFunctions_1.emailConnectApiRequest.call(this, 'PUT', `/api/webhooks/${webhookId}`, body, {}, undefined, {
+                            'X-EmailConnect-Source': 'n8n-node',
+                        });
                         returnData.push({ json: responseData });
                     }
                     else if (operation === 'delete') {

--- a/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
+++ b/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
@@ -46,19 +46,38 @@ function buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescript
 // cannot reproduce — so autoVerify via /api/webhooks/alias is the only path
 // that keeps the production webhook verified.
 // ---------------------------------------------------------------------------
-async function updateWebhookUrlAndVerify(context, webhookUrl) {
+async function updateWebhookUrlAndVerify(context, webhookUrl, existing) {
     var _a, _b;
     const staticData = context.getWorkflowStaticData('node');
     const isTestUrl = (webhookUrl !== null && webhookUrl !== void 0 ? webhookUrl : '').includes('/webhook-test/');
-    const webhookName = staticData.webhookName
+    // The upsert (updateWebhookData) overwrites name/description, and static
+    // data from the test session is not available at activation — so prefer
+    // the node parameter, then static data, then whatever the webhook already
+    // carries. Only generate a name/description when none of those exist.
+    const webhookName = context.getNodeParameter('webhookName')
+        || staticData.webhookName
+        || (existing === null || existing === void 0 ? void 0 : existing.name)
         || `n8n trigger (${context.getNode().name})`;
-    const webhookDescription = `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
+    const webhookDescription = context.getNodeParameter('webhookDescription')
+        || (existing === null || existing === void 0 ? void 0 : existing.description)
+        || `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
     const body = buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescription);
     const result = await GenericFunctions_1.emailConnectApiRequest.call(context, 'POST', '/api/webhooks/alias', body, {}, undefined, TRUSTED_SOURCE_HEADERS);
     if ((_a = result === null || result === void 0 ? void 0 : result.webhook) === null || _a === void 0 ? void 0 : _a.id)
         staticData.webhookId = result.webhook.id;
     if ((_b = result === null || result === void 0 ? void 0 : result.alias) === null || _b === void 0 ? void 0 : _b.id)
         staticData.aliasId = result.alias.id;
+}
+// ---------------------------------------------------------------------------
+// Helper: forget everything stored about the current registration.
+// ---------------------------------------------------------------------------
+function clearRegistrationState(staticData) {
+    delete staticData.domainId;
+    delete staticData.aliasId;
+    delete staticData.webhookId;
+    delete staticData.previousWebhookId;
+    delete staticData.previousDomainWebhookId;
+    delete staticData.previousCatchAllWebhookId;
 }
 // ---------------------------------------------------------------------------
 // Helper: detect whether alias/domain config changed since last save.
@@ -108,7 +127,7 @@ async function tryStoredWebhook(context, webhookUrl) {
         const webhook = await GenericFunctions_1.emailConnectApiRequest.call(context, 'GET', `/api/webhooks/${storedWebhookId}`);
         if (webhook.url !== webhookUrl) {
             // URL changed (e.g. test↔prod) — re-upsert to update URL & re-verify
-            await updateWebhookUrlAndVerify(context, webhookUrl);
+            await updateWebhookUrlAndVerify(context, webhookUrl, webhook);
             return true;
         }
         // URL matches — nothing changed
@@ -261,7 +280,7 @@ class EmailConnectTrigger {
                             const uuidHit = webhooks.find((wh) => { var _a; return (_a = wh.url) === null || _a === void 0 ? void 0 : _a.includes(currentUuid); });
                             if (uuidHit) {
                                 this.getWorkflowStaticData('node').webhookId = uuidHit.id;
-                                await updateWebhookUrlAndVerify(this, webhookUrl);
+                                await updateWebhookUrlAndVerify(this, webhookUrl, uuidHit);
                                 return true;
                             }
                         }
@@ -351,12 +370,36 @@ class EmailConnectTrigger {
                         const previousDomainWebhookId = staticData.previousDomainWebhookId;
                         const previousCatchAllWebhookId = staticData.previousCatchAllWebhookId;
                         if (domainId && webhookId) {
-                            // Ownership probe: n8n also tears down the TEST registration after a
-                            // workflow is published, and test+prod share one EmailConnect webhook
-                            // (firstOrCreate by alias email). If the webhook's URL no longer
-                            // matches this registration's URL, the other registration owns it
-                            // now — tearing down here would silently break the live workflow.
                             const ownUrl = this.getNodeWebhookUrl('default');
+                            // Preferred: one atomic backend call. It re-points/cascades the
+                            // aliases and deletes the webhook in a single transaction, and
+                            // honours expectedUrl as a CAS guard: n8n also tears down the TEST
+                            // registration after a workflow is published, and test+prod share
+                            // one EmailConnect webhook (firstOrCreate by alias email) — when
+                            // the URL no longer matches, the other registration owns it now
+                            // and nothing is torn down.
+                            try {
+                                const teardownBody = { webhookId, expectedUrl: ownUrl };
+                                if (staticData.aliasMode === 'catchall') {
+                                    const restoreWebhookId = previousCatchAllWebhookId || previousWebhookId;
+                                    if (restoreWebhookId)
+                                        teardownBody.restoreWebhookId = restoreWebhookId;
+                                }
+                                const teardown = await GenericFunctions_1.emailConnectApiRequest.call(this, 'POST', '/api/webhooks/alias/teardown', teardownBody);
+                                if (teardown === null || teardown === void 0 ? void 0 : teardown.success) {
+                                    if (teardown.action !== 'skipped_superseded') {
+                                        clearRegistrationState(staticData);
+                                    }
+                                    return true;
+                                }
+                            }
+                            catch (error) {
+                                // Older backend without the endpoint — fall back to the legacy
+                                // multi-call sequence below.
+                                this.logger.warn(`EmailConnect: atomic teardown unavailable, falling back: ${error}`);
+                            }
+                            // Ownership probe (legacy fallback) — same semantics as the
+                            // expectedUrl guard above, enforced client-side.
                             try {
                                 const currentWebhook = await GenericFunctions_1.emailConnectApiRequest.call(this, 'GET', `/api/webhooks/${webhookId}`);
                                 if ((currentWebhook === null || currentWebhook === void 0 ? void 0 : currentWebhook.url) && ownUrl && currentWebhook.url !== ownUrl) {
@@ -366,12 +409,7 @@ class EmailConnectTrigger {
                             }
                             catch {
                                 // Webhook already gone — nothing to tear down; drop stale state.
-                                delete staticData.domainId;
-                                delete staticData.aliasId;
-                                delete staticData.webhookId;
-                                delete staticData.previousWebhookId;
-                                delete staticData.previousDomainWebhookId;
-                                delete staticData.previousCatchAllWebhookId;
+                                clearRegistrationState(staticData);
                                 return true;
                             }
                             // Step 1: Detach the webhook
@@ -472,12 +510,7 @@ class EmailConnectTrigger {
                                 this.logger.warn(`EmailConnect: failed to restore previous webhook: ${error}`);
                             }
                             // Clean up stored configuration
-                            delete staticData.domainId;
-                            delete staticData.aliasId;
-                            delete staticData.webhookId;
-                            delete staticData.previousWebhookId;
-                            delete staticData.previousDomainWebhookId;
-                            delete staticData.previousCatchAllWebhookId;
+                            clearRegistrationState(staticData);
                         }
                         return true;
                     }

--- a/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
+++ b/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
@@ -351,6 +351,29 @@ class EmailConnectTrigger {
                         const previousDomainWebhookId = staticData.previousDomainWebhookId;
                         const previousCatchAllWebhookId = staticData.previousCatchAllWebhookId;
                         if (domainId && webhookId) {
+                            // Ownership probe: n8n also tears down the TEST registration after a
+                            // workflow is published, and test+prod share one EmailConnect webhook
+                            // (firstOrCreate by alias email). If the webhook's URL no longer
+                            // matches this registration's URL, the other registration owns it
+                            // now — tearing down here would silently break the live workflow.
+                            const ownUrl = this.getNodeWebhookUrl('default');
+                            try {
+                                const currentWebhook = await GenericFunctions_1.emailConnectApiRequest.call(this, 'GET', `/api/webhooks/${webhookId}`);
+                                if ((currentWebhook === null || currentWebhook === void 0 ? void 0 : currentWebhook.url) && ownUrl && currentWebhook.url !== ownUrl) {
+                                    // Superseded — keep static data; the live registration relies on it.
+                                    return true;
+                                }
+                            }
+                            catch {
+                                // Webhook already gone — nothing to tear down; drop stale state.
+                                delete staticData.domainId;
+                                delete staticData.aliasId;
+                                delete staticData.webhookId;
+                                delete staticData.previousWebhookId;
+                                delete staticData.previousDomainWebhookId;
+                                delete staticData.previousCatchAllWebhookId;
+                                return true;
+                            }
                             // Step 1: Detach the webhook
                             try {
                                 if (aliasId) {

--- a/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
+++ b/dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js
@@ -4,13 +4,15 @@ exports.EmailConnectTrigger = void 0;
 const n8n_workflow_1 = require("n8n-workflow");
 const GenericFunctions_1 = require("../EmailConnect/GenericFunctions");
 // Sanctioned trusted-source header: the backend auto-verifies webhooks
-// created/updated by known integrations (n8n-node, zapier, make). Sent on
-// every atomic upsert as belt-and-braces alongside the autoVerify body flag.
+// created/updated by known integrations (n8n-node, zapier, make). This header
+// is the sole auto-verification mechanism — the old autoVerify body flag is
+// deprecated and ignored server-side.
 const TRUSTED_SOURCE_HEADERS = { 'X-EmailConnect-Source': 'n8n-node' };
 // ---------------------------------------------------------------------------
 // Helper: build the body for the atomic POST /api/webhooks/alias upsert.
 // Shared by create() and the URL-change path so both use the one mechanism
-// that reliably (re)verifies the webhook server-side (autoVerify).
+// that reliably (re)verifies the webhook server-side (the trusted-source
+// header sent alongside this body).
 // ---------------------------------------------------------------------------
 function buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescription) {
     const aliasMode = context.getNodeParameter('aliasMode');
@@ -21,7 +23,6 @@ function buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescript
         webhookDescription,
         firstOrCreate: true,
         updateWebhookData: true,
-        autoVerify: true,
     };
     if (aliasMode === 'catchall') {
         body.aliasType = 'catchall';
@@ -42,9 +43,10 @@ function buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescript
 // atomic upsert so the URL is updated AND re-verified in one call.
 //
 // A plain PUT /api/webhooks/{id} resets `verified` to false for any non-test
-// URL, and the standalone /verify flow uses a server-generated token the node
-// cannot reproduce — so autoVerify via /api/webhooks/alias is the only path
-// that keeps the production webhook verified.
+// URL unless the trusted-source header is sent, and the standalone /verify
+// flow uses a server-generated token the node cannot reproduce — so the
+// trusted upsert via /api/webhooks/alias is the path that keeps the
+// production webhook verified.
 // ---------------------------------------------------------------------------
 async function updateWebhookUrlAndVerify(context, webhookUrl, existing) {
     var _a, _b;

--- a/nodes/EmailConnect/EmailConnect.node.ts
+++ b/nodes/EmailConnect/EmailConnect.node.ts
@@ -642,7 +642,11 @@ export class EmailConnect implements INodeType {
 						const body: any = { name, url };
 						if (description) body.description = description;
 
-						const responseData = await emailConnectApiRequest.call(this, 'PUT', `/api/webhooks/${webhookId}`, body);
+						// Trusted-source header keeps the webhook verified on URL change —
+						// without it the backend resets `verified` for any non-test URL.
+						const responseData = await emailConnectApiRequest.call(this, 'PUT', `/api/webhooks/${webhookId}`, body, {}, undefined, {
+							'X-EmailConnect-Source': 'n8n-node',
+						});
 						returnData.push({ json: responseData });
 					} else if (operation === 'delete') {
 						const webhookId = this.getNodeParameter('webhookId', i) as string;

--- a/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
+++ b/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
@@ -12,14 +12,16 @@ import {
 import { emailConnectApiRequest, getDomainOptions } from '../EmailConnect/GenericFunctions';
 
 // Sanctioned trusted-source header: the backend auto-verifies webhooks
-// created/updated by known integrations (n8n-node, zapier, make). Sent on
-// every atomic upsert as belt-and-braces alongside the autoVerify body flag.
+// created/updated by known integrations (n8n-node, zapier, make). This header
+// is the sole auto-verification mechanism — the old autoVerify body flag is
+// deprecated and ignored server-side.
 const TRUSTED_SOURCE_HEADERS = { 'X-EmailConnect-Source': 'n8n-node' };
 
 // ---------------------------------------------------------------------------
 // Helper: build the body for the atomic POST /api/webhooks/alias upsert.
 // Shared by create() and the URL-change path so both use the one mechanism
-// that reliably (re)verifies the webhook server-side (autoVerify).
+// that reliably (re)verifies the webhook server-side (the trusted-source
+// header sent alongside this body).
 // ---------------------------------------------------------------------------
 function buildWebhookAliasBody(
 	context: IHookFunctions,
@@ -36,7 +38,6 @@ function buildWebhookAliasBody(
 		webhookDescription,
 		firstOrCreate: true,
 		updateWebhookData: true,
-		autoVerify: true,
 	};
 
 	if (aliasMode === 'catchall') {
@@ -59,9 +60,10 @@ function buildWebhookAliasBody(
 // atomic upsert so the URL is updated AND re-verified in one call.
 //
 // A plain PUT /api/webhooks/{id} resets `verified` to false for any non-test
-// URL, and the standalone /verify flow uses a server-generated token the node
-// cannot reproduce — so autoVerify via /api/webhooks/alias is the only path
-// that keeps the production webhook verified.
+// URL unless the trusted-source header is sent, and the standalone /verify
+// flow uses a server-generated token the node cannot reproduce — so the
+// trusted upsert via /api/webhooks/alias is the path that keeps the
+// production webhook verified.
 // ---------------------------------------------------------------------------
 async function updateWebhookUrlAndVerify(
 	context: IHookFunctions,

--- a/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
+++ b/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
@@ -66,12 +66,21 @@ function buildWebhookAliasBody(
 async function updateWebhookUrlAndVerify(
 	context: IHookFunctions,
 	webhookUrl: string,
+	existing?: { name?: string; description?: string },
 ): Promise<void> {
 	const staticData = context.getWorkflowStaticData('node');
 	const isTestUrl = (webhookUrl ?? '').includes('/webhook-test/');
-	const webhookName = (staticData.webhookName as string)
+	// The upsert (updateWebhookData) overwrites name/description, and static
+	// data from the test session is not available at activation — so prefer
+	// the node parameter, then static data, then whatever the webhook already
+	// carries. Only generate a name/description when none of those exist.
+	const webhookName = (context.getNodeParameter('webhookName') as string)
+		|| (staticData.webhookName as string)
+		|| existing?.name
 		|| `n8n trigger (${context.getNode().name})`;
-	const webhookDescription = `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
+	const webhookDescription = (context.getNodeParameter('webhookDescription') as string)
+		|| existing?.description
+		|| `Auto-created webhook for n8n trigger node: ${context.getNode().name} (${isTestUrl ? 'Test' : 'Production'})`;
 
 	const body = buildWebhookAliasBody(context, webhookUrl, webhookName, webhookDescription);
 	const result = await emailConnectApiRequest.call(
@@ -86,6 +95,18 @@ async function updateWebhookUrlAndVerify(
 
 	if (result?.webhook?.id) staticData.webhookId = result.webhook.id;
 	if (result?.alias?.id) staticData.aliasId = result.alias.id;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: forget everything stored about the current registration.
+// ---------------------------------------------------------------------------
+function clearRegistrationState(staticData: IDataObject): void {
+	delete staticData.domainId;
+	delete staticData.aliasId;
+	delete staticData.webhookId;
+	delete staticData.previousWebhookId;
+	delete staticData.previousDomainWebhookId;
+	delete staticData.previousCatchAllWebhookId;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +169,7 @@ async function tryStoredWebhook(
 
 		if (webhook.url !== webhookUrl) {
 			// URL changed (e.g. test↔prod) — re-upsert to update URL & re-verify
-			await updateWebhookUrlAndVerify(context, webhookUrl);
+			await updateWebhookUrlAndVerify(context, webhookUrl, webhook);
 			return true;
 		}
 
@@ -308,7 +329,7 @@ export class EmailConnectTrigger implements INodeType {
 						const uuidHit = webhooks.find((wh: any) => wh.url?.includes(currentUuid));
 						if (uuidHit) {
 							this.getWorkflowStaticData('node').webhookId = uuidHit.id;
-							await updateWebhookUrlAndVerify(this, webhookUrl);
+							await updateWebhookUrlAndVerify(this, webhookUrl, uuidHit);
 							return true;
 						}
 					}
@@ -413,12 +434,36 @@ export class EmailConnectTrigger implements INodeType {
 					const previousCatchAllWebhookId = staticData.previousCatchAllWebhookId as string;
 
 					if (domainId && webhookId) {
-						// Ownership probe: n8n also tears down the TEST registration after a
-						// workflow is published, and test+prod share one EmailConnect webhook
-						// (firstOrCreate by alias email). If the webhook's URL no longer
-						// matches this registration's URL, the other registration owns it
-						// now — tearing down here would silently break the live workflow.
 						const ownUrl = this.getNodeWebhookUrl('default') as string;
+
+						// Preferred: one atomic backend call. It re-points/cascades the
+						// aliases and deletes the webhook in a single transaction, and
+						// honours expectedUrl as a CAS guard: n8n also tears down the TEST
+						// registration after a workflow is published, and test+prod share
+						// one EmailConnect webhook (firstOrCreate by alias email) — when
+						// the URL no longer matches, the other registration owns it now
+						// and nothing is torn down.
+						try {
+							const teardownBody: IDataObject = { webhookId, expectedUrl: ownUrl };
+							if (staticData.aliasMode === 'catchall') {
+								const restoreWebhookId = previousCatchAllWebhookId || previousWebhookId;
+								if (restoreWebhookId) teardownBody.restoreWebhookId = restoreWebhookId;
+							}
+							const teardown = await emailConnectApiRequest.call(this, 'POST', '/api/webhooks/alias/teardown', teardownBody);
+							if (teardown?.success) {
+								if (teardown.action !== 'skipped_superseded') {
+									clearRegistrationState(staticData);
+								}
+								return true;
+							}
+						} catch (error) {
+							// Older backend without the endpoint — fall back to the legacy
+							// multi-call sequence below.
+							this.logger.warn(`EmailConnect: atomic teardown unavailable, falling back: ${error}`);
+						}
+
+						// Ownership probe (legacy fallback) — same semantics as the
+						// expectedUrl guard above, enforced client-side.
 						try {
 							const currentWebhook = await emailConnectApiRequest.call(this, 'GET', `/api/webhooks/${webhookId}`);
 							if (currentWebhook?.url && ownUrl && currentWebhook.url !== ownUrl) {
@@ -427,12 +472,7 @@ export class EmailConnectTrigger implements INodeType {
 							}
 						} catch {
 							// Webhook already gone — nothing to tear down; drop stale state.
-							delete staticData.domainId;
-							delete staticData.aliasId;
-							delete staticData.webhookId;
-							delete staticData.previousWebhookId;
-							delete staticData.previousDomainWebhookId;
-							delete staticData.previousCatchAllWebhookId;
+							clearRegistrationState(staticData);
 							return true;
 						}
 
@@ -532,12 +572,7 @@ export class EmailConnectTrigger implements INodeType {
 						}
 
 						// Clean up stored configuration
-						delete staticData.domainId;
-						delete staticData.aliasId;
-						delete staticData.webhookId;
-						delete staticData.previousWebhookId;
-						delete staticData.previousDomainWebhookId;
-						delete staticData.previousCatchAllWebhookId;
+						clearRegistrationState(staticData);
 					}
 
 					return true;

--- a/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
+++ b/nodes/EmailConnectTrigger/EmailConnectTrigger.node.ts
@@ -413,6 +413,29 @@ export class EmailConnectTrigger implements INodeType {
 					const previousCatchAllWebhookId = staticData.previousCatchAllWebhookId as string;
 
 					if (domainId && webhookId) {
+						// Ownership probe: n8n also tears down the TEST registration after a
+						// workflow is published, and test+prod share one EmailConnect webhook
+						// (firstOrCreate by alias email). If the webhook's URL no longer
+						// matches this registration's URL, the other registration owns it
+						// now — tearing down here would silently break the live workflow.
+						const ownUrl = this.getNodeWebhookUrl('default') as string;
+						try {
+							const currentWebhook = await emailConnectApiRequest.call(this, 'GET', `/api/webhooks/${webhookId}`);
+							if (currentWebhook?.url && ownUrl && currentWebhook.url !== ownUrl) {
+								// Superseded — keep static data; the live registration relies on it.
+								return true;
+							}
+						} catch {
+							// Webhook already gone — nothing to tear down; drop stale state.
+							delete staticData.domainId;
+							delete staticData.aliasId;
+							delete staticData.webhookId;
+							delete staticData.previousWebhookId;
+							delete staticData.previousDomainWebhookId;
+							delete staticData.previousCatchAllWebhookId;
+							return true;
+						}
+
 						// Step 1: Detach the webhook
 						try {
 							if (aliasId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-emailconnect",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-emailconnect",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "n8n community node for EmailConnect - Email automation and webhook integration",
   "keywords": [
     "n8n-community-node-package",

--- a/test/delete-teardown-guard.test.js
+++ b/test/delete-teardown-guard.test.js
@@ -1,14 +1,15 @@
 /**
- * Test for the delete() teardown guard.
+ * Tests for delete() teardown.
  *
- * n8n tears down the TEST webhook registration (delete()) even after the
- * workflow has been published — and test+prod share one EmailConnect
- * webhook/alias (firstOrCreate by email). Without a guard, the test-session
- * teardown re-points the alias back to the previous webhook and breaks the
- * freshly activated production registration.
+ * Preferred path: one atomic POST /api/webhooks/alias/teardown call. The
+ * backend re-points/cascades aliases and deletes the webhook in a single
+ * transaction, and honours expectedUrl as a CAS guard: when the webhook's URL
+ * no longer matches this registration's URL (n8n test→prod handoff), nothing
+ * is torn down — the other registration owns the webhook now.
  *
- * Guard: delete() must first GET the stored webhook and SKIP teardown when
- * the webhook's current URL no longer matches this registration's URL.
+ * Fallback path (older backend without the endpoint): the legacy multi-call
+ * sequence, protected by a client-side ownership probe with the same
+ * URL-comparison semantics.
  */
 
 const { EmailConnectTrigger } = require('../dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js');
@@ -24,7 +25,7 @@ const TEST_URL = 'https://n8n.example.com/webhook-test/d88abf53-c967-462c-b371-d
 const PROD_URL = 'https://n8n.example.com/webhook/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
 const WEBHOOK_ID = 'stored-webhook-id';
 
-describe('EmailConnectTrigger delete() teardown guard', () => {
+describe('EmailConnectTrigger delete()', () => {
   let triggerNode;
   let mockContext;
   let mockStaticData;
@@ -45,7 +46,7 @@ describe('EmailConnectTrigger delete() teardown guard', () => {
     };
 
     mockContext = {
-      getNodeWebhookUrl: jest.fn(),
+      getNodeWebhookUrl: jest.fn().mockReturnValue(TEST_URL),
       getWorkflowStaticData: jest.fn().mockReturnValue(mockStaticData),
       getNode: jest.fn().mockReturnValue({ name: 'Test EmailConnect Trigger' }),
       getNodeParameter: jest.fn((param) => {
@@ -61,53 +62,98 @@ describe('EmailConnectTrigger delete() teardown guard', () => {
     };
   });
 
-  test('skips teardown when the webhook URL was switched by another registration (test→prod handoff)', async () => {
-    // This registration is the TEST one being torn down…
-    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
-    // …but the webhook has since been re-pointed to the PROD URL by activation.
-    emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: PROD_URL, verified: true });
+  describe('atomic teardown endpoint', () => {
+    test('tears down via a single POST /api/webhooks/alias/teardown call', async () => {
+      emailConnectApiRequest.mockResolvedValueOnce({ success: true, action: 'deleted' });
 
-    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
 
-    expect(result).toBe(true);
-    // Only the ownership probe — no detach/delete/restore calls.
-    expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
-    expect(emailConnectApiRequest).toHaveBeenCalledWith('GET', `/api/webhooks/${WEBHOOK_ID}`);
-    // Static data must survive — the live (prod) registration still relies on it.
-    expect(mockStaticData.webhookId).toBe(WEBHOOK_ID);
-    expect(mockStaticData.aliasId).toBe('test-alias-id');
-    expect(mockStaticData.domainId).toBe('test-domain-id');
+      expect(result).toBe(true);
+      expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
+      expect(emailConnectApiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/api/webhooks/alias/teardown',
+        expect.objectContaining({ webhookId: WEBHOOK_ID, expectedUrl: TEST_URL }),
+      );
+      // Real teardown happened — registration state is gone.
+      expect(mockStaticData.webhookId).toBeUndefined();
+      expect(mockStaticData.aliasId).toBeUndefined();
+    });
+
+    test('keeps static data when the backend reports the registration as superseded', async () => {
+      emailConnectApiRequest.mockResolvedValueOnce({
+        success: true,
+        action: 'skipped_superseded',
+        webhook: { id: WEBHOOK_ID, url: PROD_URL },
+      });
+
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+      expect(result).toBe(true);
+      expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
+      // The live (prod) registration still relies on this state.
+      expect(mockStaticData.webhookId).toBe(WEBHOOK_ID);
+      expect(mockStaticData.aliasId).toBe('test-alias-id');
+    });
+
+    test('passes the previous catch-all webhook as restore target in catchall mode', async () => {
+      mockStaticData.aliasMode = 'catchall';
+      mockStaticData.previousCatchAllWebhookId = 'prev-catchall-webhook';
+      delete mockStaticData.aliasLocalPart;
+      emailConnectApiRequest.mockResolvedValueOnce({ success: true, action: 'restored_and_deleted' });
+
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+      expect(result).toBe(true);
+      expect(emailConnectApiRequest).toHaveBeenCalledWith(
+        'POST',
+        '/api/webhooks/alias/teardown',
+        expect.objectContaining({
+          webhookId: WEBHOOK_ID,
+          restoreWebhookId: 'prev-catchall-webhook',
+        }),
+      );
+    });
   });
 
-  test('proceeds with teardown when the webhook URL still belongs to this registration', async () => {
-    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
-    // Ownership probe: URL matches → this registration still owns the webhook.
-    emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: TEST_URL, verified: true });
-    // Remaining teardown calls succeed.
-    emailConnectApiRequest.mockResolvedValue({ success: true });
+  describe('legacy fallback (backend without the teardown endpoint)', () => {
+    test('skips teardown when the webhook URL was switched by another registration', async () => {
+      // Teardown endpoint missing (older backend) …
+      emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+      // … ownership probe: webhook now carries the PROD URL.
+      emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: PROD_URL, verified: true });
 
-    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
 
-    expect(result).toBe(true);
-    const methods = emailConnectApiRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
-    expect(methods).toContain(`DELETE /api/webhooks/${WEBHOOK_ID}`);
-    // Static data cleaned up after a real teardown.
-    expect(mockStaticData.webhookId).toBeUndefined();
-    expect(mockStaticData.aliasId).toBeUndefined();
-  });
+      expect(result).toBe(true);
+      expect(emailConnectApiRequest).toHaveBeenCalledTimes(2);
+      expect(emailConnectApiRequest).toHaveBeenNthCalledWith(2, 'GET', `/api/webhooks/${WEBHOOK_ID}`);
+      expect(mockStaticData.webhookId).toBe(WEBHOOK_ID);
+    });
 
-  test('skips teardown and cleans static data when the stored webhook no longer exists', async () => {
-    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
-    emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+    test('proceeds with legacy teardown when the webhook still belongs to this registration', async () => {
+      emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+      emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: TEST_URL, verified: true });
+      emailConnectApiRequest.mockResolvedValue({ success: true });
 
-    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
 
-    expect(result).toBe(true);
-    expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
-    const methods = emailConnectApiRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
-    expect(methods).not.toContain(`DELETE /api/webhooks/${WEBHOOK_ID}`);
-    // Nothing left to tear down later — clear the stale registration state.
-    expect(mockStaticData.webhookId).toBeUndefined();
-    expect(mockStaticData.aliasId).toBeUndefined();
+      expect(result).toBe(true);
+      const methods = emailConnectApiRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
+      expect(methods).toContain(`DELETE /api/webhooks/${WEBHOOK_ID}`);
+      expect(mockStaticData.webhookId).toBeUndefined();
+    });
+
+    test('cleans static data when the stored webhook no longer exists', async () => {
+      emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+      emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+
+      const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+      expect(result).toBe(true);
+      expect(emailConnectApiRequest).toHaveBeenCalledTimes(2);
+      expect(mockStaticData.webhookId).toBeUndefined();
+      expect(mockStaticData.aliasId).toBeUndefined();
+    });
   });
 });

--- a/test/delete-teardown-guard.test.js
+++ b/test/delete-teardown-guard.test.js
@@ -1,0 +1,113 @@
+/**
+ * Test for the delete() teardown guard.
+ *
+ * n8n tears down the TEST webhook registration (delete()) even after the
+ * workflow has been published — and test+prod share one EmailConnect
+ * webhook/alias (firstOrCreate by email). Without a guard, the test-session
+ * teardown re-points the alias back to the previous webhook and breaks the
+ * freshly activated production registration.
+ *
+ * Guard: delete() must first GET the stored webhook and SKIP teardown when
+ * the webhook's current URL no longer matches this registration's URL.
+ */
+
+const { EmailConnectTrigger } = require('../dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js');
+
+jest.mock('../dist/nodes/EmailConnect/GenericFunctions.js', () => ({
+  emailConnectApiRequest: jest.fn(),
+  getDomainOptions: jest.fn().mockResolvedValue([]),
+}));
+
+const { emailConnectApiRequest } = require('../dist/nodes/EmailConnect/GenericFunctions.js');
+
+const TEST_URL = 'https://n8n.example.com/webhook-test/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+const PROD_URL = 'https://n8n.example.com/webhook/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+const WEBHOOK_ID = 'stored-webhook-id';
+
+describe('EmailConnectTrigger delete() teardown guard', () => {
+  let triggerNode;
+  let mockContext;
+  let mockStaticData;
+
+  beforeEach(() => {
+    triggerNode = new EmailConnectTrigger();
+    emailConnectApiRequest.mockReset();
+
+    mockStaticData = {
+      domainId: 'test-domain-id',
+      aliasId: 'test-alias-id',
+      webhookId: WEBHOOK_ID,
+      previousWebhookId: 'previous-webhook-id',
+      previousDomainWebhookId: '',
+      previousCatchAllWebhookId: '',
+      aliasMode: 'specific',
+      aliasLocalPart: 'support',
+    };
+
+    mockContext = {
+      getNodeWebhookUrl: jest.fn(),
+      getWorkflowStaticData: jest.fn().mockReturnValue(mockStaticData),
+      getNode: jest.fn().mockReturnValue({ name: 'Test EmailConnect Trigger' }),
+      getNodeParameter: jest.fn((param) => {
+        const params = {
+          aliasMode: 'specific',
+          domainId: 'test-domain-id',
+          aliasLocalPart: 'support',
+        };
+        return params[param] || '';
+      }),
+      getCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-api-key' }),
+      logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    };
+  });
+
+  test('skips teardown when the webhook URL was switched by another registration (test→prod handoff)', async () => {
+    // This registration is the TEST one being torn down…
+    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
+    // …but the webhook has since been re-pointed to the PROD URL by activation.
+    emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: PROD_URL, verified: true });
+
+    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+    expect(result).toBe(true);
+    // Only the ownership probe — no detach/delete/restore calls.
+    expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
+    expect(emailConnectApiRequest).toHaveBeenCalledWith('GET', `/api/webhooks/${WEBHOOK_ID}`);
+    // Static data must survive — the live (prod) registration still relies on it.
+    expect(mockStaticData.webhookId).toBe(WEBHOOK_ID);
+    expect(mockStaticData.aliasId).toBe('test-alias-id');
+    expect(mockStaticData.domainId).toBe('test-domain-id');
+  });
+
+  test('proceeds with teardown when the webhook URL still belongs to this registration', async () => {
+    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
+    // Ownership probe: URL matches → this registration still owns the webhook.
+    emailConnectApiRequest.mockResolvedValueOnce({ id: WEBHOOK_ID, url: TEST_URL, verified: true });
+    // Remaining teardown calls succeed.
+    emailConnectApiRequest.mockResolvedValue({ success: true });
+
+    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+    expect(result).toBe(true);
+    const methods = emailConnectApiRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
+    expect(methods).toContain(`DELETE /api/webhooks/${WEBHOOK_ID}`);
+    // Static data cleaned up after a real teardown.
+    expect(mockStaticData.webhookId).toBeUndefined();
+    expect(mockStaticData.aliasId).toBeUndefined();
+  });
+
+  test('skips teardown and cleans static data when the stored webhook no longer exists', async () => {
+    mockContext.getNodeWebhookUrl.mockReturnValue(TEST_URL);
+    emailConnectApiRequest.mockRejectedValueOnce(new Error('404 Not Found'));
+
+    const result = await triggerNode.webhookMethods.default.delete.call(mockContext);
+
+    expect(result).toBe(true);
+    expect(emailConnectApiRequest).toHaveBeenCalledTimes(1);
+    const methods = emailConnectApiRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
+    expect(methods).not.toContain(`DELETE /api/webhooks/${WEBHOOK_ID}`);
+    // Nothing left to tear down later — clear the stale registration state.
+    expect(mockStaticData.webhookId).toBeUndefined();
+    expect(mockStaticData.aliasId).toBeUndefined();
+  });
+});

--- a/test/trusted-source-header.test.js
+++ b/test/trusted-source-header.test.js
@@ -2,7 +2,8 @@
  * The X-EmailConnect-Source trusted-source header must be sent on every
  * POST /api/webhooks/alias upsert. The backend auto-verifies webhooks
  * created/updated by known integrations (n8n-node, zapier, make) based on
- * this header — belt-and-braces alongside the autoVerify body flag.
+ * this header — the sole verification mechanism now that the autoVerify
+ * body flag is deprecated and ignored server-side.
  */
 
 const { EmailConnectTrigger } = require('../dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js');
@@ -74,7 +75,6 @@ describe('Trusted-source header on webhook/alias upsert', () => {
       expect.objectContaining({
         domainId: 'test-domain-id',
         webhookUrl,
-        autoVerify: true,
       }),
       {},
       undefined,
@@ -108,7 +108,7 @@ describe('Trusted-source header on webhook/alias upsert', () => {
       2,
       'POST',
       '/api/webhooks/alias',
-      expect.objectContaining({ webhookUrl: currentUrl, autoVerify: true }),
+      expect.objectContaining({ webhookUrl: currentUrl }),
       {},
       undefined,
       expect.objectContaining(TRUSTED_HEADERS),

--- a/test/webhook-name-preservation.test.js
+++ b/test/webhook-name-preservation.test.js
@@ -1,0 +1,145 @@
+/**
+ * The test→prod URL switch must not clobber the user's webhook name.
+ *
+ * Observed: a user names their webhook "debug-flow-webhook" (node parameter),
+ * tests, then publishes. The production activation runs with empty static
+ * data, so updateWebhookUrlAndVerify fell back to "n8n trigger (<node>)" and
+ * the upsert (updateWebhookData: true) renamed the webhook — looking like the
+ * original webhook vanished and a new one appeared.
+ *
+ * Name/description precedence on URL switch:
+ *   node parameter → staticData → the webhook's current values → generated.
+ */
+
+const { EmailConnectTrigger } = require('../dist/nodes/EmailConnectTrigger/EmailConnectTrigger.node.js');
+
+jest.mock('../dist/nodes/EmailConnect/GenericFunctions.js', () => ({
+  emailConnectApiRequest: jest.fn(),
+  getDomainOptions: jest.fn().mockResolvedValue([]),
+}));
+
+const { emailConnectApiRequest } = require('../dist/nodes/EmailConnect/GenericFunctions.js');
+
+const TEST_URL = 'https://n8n.example.com/webhook-test/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+const PROD_URL = 'https://n8n.example.com/webhook/d88abf53-c967-462c-b371-ddd8230e7939/emailconnect';
+const WEBHOOK_ID = 'existing-webhook-id';
+
+describe('webhook name preservation on URL switch', () => {
+  let triggerNode;
+  let mockContext;
+  let mockStaticData;
+  let nodeParams;
+
+  beforeEach(() => {
+    triggerNode = new EmailConnectTrigger();
+    emailConnectApiRequest.mockReset();
+
+    // Activation context: static data did NOT survive the test session.
+    mockStaticData = {};
+    nodeParams = {
+      aliasMode: 'specific',
+      domainId: 'test-domain-id',
+      aliasLocalPart: 'debug-flow-alias',
+      webhookName: '',
+      webhookDescription: '',
+    };
+
+    mockContext = {
+      getNodeWebhookUrl: jest.fn().mockReturnValue(PROD_URL),
+      getWorkflowStaticData: jest.fn().mockReturnValue(mockStaticData),
+      getNode: jest.fn().mockReturnValue({ name: 'EmailConnect Trigger' }),
+      getNodeParameter: jest.fn((param) => nodeParams[param] ?? ''),
+      getCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-api-key' }),
+      logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    };
+  });
+
+  test('keeps the webhook\'s current name and description when no parameter is set (UUID-match path)', async () => {
+    // checkExists fallback: list lookup finds the test-URL webhook by UUID.
+    emailConnectApiRequest
+      .mockResolvedValueOnce({
+        webhooks: [
+          {
+            id: WEBHOOK_ID,
+            url: TEST_URL,
+            name: 'debug-flow-webhook',
+            description: 'My own description',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ success: true, webhook: { id: WEBHOOK_ID }, alias: { id: 'alias-id' } });
+
+    const result = await triggerNode.webhookMethods.default.checkExists.call(mockContext);
+
+    expect(result).toBe(true);
+    expect(emailConnectApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/webhooks/alias',
+      expect.objectContaining({
+        webhookUrl: PROD_URL,
+        webhookName: 'debug-flow-webhook',
+        webhookDescription: 'My own description',
+      }),
+      {},
+      undefined,
+      { 'X-EmailConnect-Source': 'n8n-node' },
+    );
+  });
+
+  test('keeps the webhook\'s current name on the stored-webhook path too', async () => {
+    mockStaticData.webhookId = WEBHOOK_ID;
+    mockStaticData.aliasMode = 'specific';
+    mockStaticData.domainId = 'test-domain-id';
+    mockStaticData.aliasLocalPart = 'debug-flow-alias';
+
+    emailConnectApiRequest
+      .mockResolvedValueOnce({
+        id: WEBHOOK_ID,
+        url: TEST_URL,
+        name: 'debug-flow-webhook',
+        description: 'My own description',
+      })
+      .mockResolvedValueOnce({ success: true, webhook: { id: WEBHOOK_ID }, alias: { id: 'alias-id' } });
+
+    const result = await triggerNode.webhookMethods.default.checkExists.call(mockContext);
+
+    expect(result).toBe(true);
+    expect(emailConnectApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/webhooks/alias',
+      expect.objectContaining({
+        webhookName: 'debug-flow-webhook',
+        webhookDescription: 'My own description',
+      }),
+      {},
+      undefined,
+      { 'X-EmailConnect-Source': 'n8n-node' },
+    );
+  });
+
+  test('an explicit webhookName parameter wins over the current name', async () => {
+    nodeParams.webhookName = 'param-name';
+    mockStaticData.webhookId = WEBHOOK_ID;
+    mockStaticData.aliasMode = 'specific';
+    mockStaticData.domainId = 'test-domain-id';
+    mockStaticData.aliasLocalPart = 'debug-flow-alias';
+
+    emailConnectApiRequest
+      .mockResolvedValueOnce({ id: WEBHOOK_ID, url: TEST_URL, name: 'debug-flow-webhook' })
+      .mockResolvedValueOnce({ success: true, webhook: { id: WEBHOOK_ID }, alias: { id: 'alias-id' } });
+
+    await triggerNode.webhookMethods.default.checkExists.call(mockContext);
+
+    expect(emailConnectApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/webhooks/alias',
+      expect.objectContaining({ webhookName: 'param-name' }),
+      {},
+      undefined,
+      { 'X-EmailConnect-Source': 'n8n-node' },
+    );
+  });
+});

--- a/test/webhook-url-switching.test.js
+++ b/test/webhook-url-switching.test.js
@@ -60,7 +60,7 @@ describe('EmailConnect Webhook URL Switching', () => {
       mockStaticData.aliasId = 'test-alias-id';
 
       // 1. GET webhook (tryStoredWebhook) — URL differs
-      // 2. POST /api/webhooks/alias (atomic upsert: update URL + autoVerify)
+      // 2. POST /api/webhooks/alias (atomic upsert: update URL, auto-verified via trusted-source header)
       emailConnectApiRequest
         .mockResolvedValueOnce({ id: webhookId, url: productionUrl, name: 'Test Webhook', verified: true })
         .mockResolvedValueOnce({ success: true, webhook: { id: webhookId }, alias: { id: 'test-alias-id' } });
@@ -75,7 +75,6 @@ describe('EmailConnect Webhook URL Switching', () => {
           webhookUrl: testUrl,
           aliasType: 'specific',
           localPart: 'support',
-          autoVerify: true,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Test)',
         }),
         {},
@@ -107,7 +106,6 @@ describe('EmailConnect Webhook URL Switching', () => {
       expect(emailConnectApiRequest).toHaveBeenNthCalledWith(2, 'POST', '/api/webhooks/alias',
         expect.objectContaining({
           webhookUrl: productionUrl,
-          autoVerify: true,
           webhookDescription: 'Auto-created webhook for n8n trigger node: Test EmailConnect Trigger (Production)',
         }),
         {},
@@ -215,7 +213,7 @@ describe('EmailConnect Webhook URL Switching', () => {
 
       // Should re-upsert via the atomic endpoint with the current (production) URL
       expect(emailConnectApiRequest).toHaveBeenNthCalledWith(2, 'POST', '/api/webhooks/alias',
-        expect.objectContaining({ webhookUrl: currentUrl, autoVerify: true }),
+        expect.objectContaining({ webhookUrl: currentUrl }),
         {},
         undefined,
         { 'X-EmailConnect-Source': 'n8n-node' },


### PR DESCRIPTION
## Problems

1. **Published workflows silently lost their routing.** After publishing, n8n still tears down the **test** webhook registration via the node's `delete()`. Test and prod share a single EmailConnect webhook+alias (`firstOrCreate` by alias email), so the teardown re-pointed the alias back to the previous webhook (observed live: trigger webhook orphaned with `aliasCount: 0`).
2. **Teardown was broken against the backend schema.** `Alias.webhookId` is NOT NULL (detach with `null` always fails) and webhook deletion refuses while aliases are attached — so webhooks leaked and only the harmful 'restore' step ever succeeded.
3. **The test→prod URL switch renamed the user's webhook.** Activation runs without the test session's static data, so `updateWebhookUrlAndVerify` fell back to `n8n trigger (<node>)` and the upsert overwrote e.g. `debug-flow-webhook` — looking like the webhook vanished and a stranger appeared.

## Fixes

- `delete()` prefers a single atomic `POST /api/webhooks/alias/teardown` call (new backend endpoint): aliases re-pointed/cascaded and webhook deleted in one transaction, with `expectedUrl` as a CAS guard that no-ops when the registration was superseded. Falls back to the legacy sequence (now protected by a client-side ownership probe with the same URL semantics) on older backends.
- Name/description precedence on URL switch: node parameter → staticData → the webhook's current values → generated fallback.

## Tests

9 new/updated tests (`test/delete-teardown-guard.test.js`, `test/webhook-name-preservation.test.js`), TDD (watched fail first). Full suite: 47/47, lint clean.

Companion backend branch: `feature/webhook-alias-teardown` in emailconnect-app (endpoint). The node works against older backends via the fallback, so merge order is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
